### PR TITLE
Improved exception handling when reading and writing a file

### DIFF
--- a/src/CompactJson/CompactJsonException.cs
+++ b/src/CompactJson/CompactJsonException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace MSBuild.CompactJsonResources
+{
+    public class CompactJsonException : Exception
+    {
+        public CompactJsonException(string filePath, Exception inner)
+            :base(CreateMess(filePath, inner), inner)
+        {
+        }
+
+        static string CreateMess(string filePath, Exception inner) =>
+            $"Failed to process {filePath} See Build Output. {Environment.NewLine}" +
+            $"{inner.GetType()}: {inner.Message}";
+    }
+}
+

--- a/src/CompactJson/JsonFile.cs
+++ b/src/CompactJson/JsonFile.cs
@@ -54,24 +54,31 @@ namespace MSBuild.CompactJsonResources
 
         public TaskItem WriteCompactTempFile()
         {
-            using var frs = File.OpenRead(FullPath);
-            using var jDoc = JsonDocument.Parse(frs,
-                new JsonDocumentOptions { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
+            try
+            {
+                using var frs = File.OpenRead(FullPath);
+                using var jDoc = JsonDocument.Parse(frs,
+                    new JsonDocumentOptions { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
 
-            var directory = Path.GetDirectoryName(TempFullPath);
+                var directory = Path.GetDirectoryName(TempFullPath);
 
-            if (!Directory.Exists(directory))
-                Directory.CreateDirectory(directory);
+                if (!Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
 
-            if (File.Exists(TempFullPath))
-                File.Delete(TempFullPath);
+                if (File.Exists(TempFullPath))
+                    File.Delete(TempFullPath);
 
-            using var fws = File.OpenWrite(TempFullPath);
-            using var writer = new Utf8JsonWriter(fws);
-            jDoc.WriteTo(writer);
-            writer.Flush();
-            fws.Flush();
-
+                using var fws = File.OpenWrite(TempFullPath);
+                using var writer = new Utf8JsonWriter(fws);
+                jDoc.WriteTo(writer);
+                writer.Flush();
+                fws.Flush();
+            }
+            catch(Exception ex)
+            {
+                throw new CompactJsonException(FullPath, ex);
+            }
+            
             return GetTaskItem();
         }
 


### PR DESCRIPTION
Exceptions thrown when reading and writing files will be wrapped in `CompactJsonException`.

```csharp
static string CreateMess(string filePath, Exception inner) =>
    $"Failed to process {filePath} See Build Output. {Environment.NewLine}" +
    $"{inner.GetType()}: {inner.Message}";
```

These changes will add information to Build Output about what type of exception thrown and when processing which file
