### PR TITLE
set TargetFramework to .NET Standard 2.0

### DIFF
--- a/src/CompactJson/JsonFile.cs
+++ b/src/CompactJson/JsonFile.cs
@@ -12,7 +12,7 @@ namespace MSBuild.CompactJsonResources
         const string definingProjectFullPath = "DefiningProjectFullPath";
         const string definingProjectName = "DefiningProjectName";
         const string definingProjectExtension = "DefiningProjectExtension";
-        const char dotChar = '.';
+        const string dot = ".";
 
         readonly ITaskItem item;
         readonly string tempOutputPath;
@@ -131,8 +131,8 @@ namespace MSBuild.CompactJsonResources
             if (Extension.IsEmpty())
                 Extension = Path.GetExtension(FullPath);
 
-            if (!Extension.IsEmpty() && !Extension.StartsWith(dotChar))
-                Extension = dotChar + Extension;
+            if (!Extension.IsEmpty() && !Extension.StartsWith(dot))
+                Extension = dot + Extension;
 
             if (Filename.IsEmpty() && Extension.IsEmpty())
                 throw new ArgumentException($"The {nameof(Filename)} and {nameof(Extension)} could not be determined in {item.ToString(null)}");

--- a/src/CompactJson/MSBuild.CompactJsonResources.csproj
+++ b/src/CompactJson/MSBuild.CompactJsonResources.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DevelopmentDependency>true</DevelopmentDependency>
 		<IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/TestMSBuildTasks/TestMSBuildTasks.csproj
+++ b/src/TestMSBuildTasks/TestMSBuildTasks.csproj
@@ -16,5 +16,5 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.CompactJsonResources" Version="1.0.2" PrivateAssets="all"/>
 	</ItemGroup>
-	<!--<Import Project="..\CompactJson\bin\$(Configuration)\netstandard2.1\MSBuild.CompactJsonResources.targets" />-->
+	<!--<Import Project="..\CompactJson\bin\$(Configuration)\netstandard2.0\MSBuild.CompactJsonResources.targets" />-->
 </Project>


### PR DESCRIPTION
This pull request solves issue #9.

There is no string.StartsWith(char) on .NET Standard 2.0, so it is replaced with string.StartsWith(string).
Everything else unchanged except that.